### PR TITLE
Fixed datatime handling for non-timezone aware datetimes

### DIFF
--- a/pg_stream_copy/protocol.py
+++ b/pg_stream_copy/protocol.py
@@ -156,6 +156,7 @@ def build_timestamp_tz(value: datetime):
     timestamp_ms = int((value.timestamp() - pg_timestamp_tz_epoch) * 1_000_000)
     return _build_value(pack('>q', timestamp_ms))
 
+
 def build_json(value: str) -> bytes:
     return build_character_varying(value)
 

--- a/pg_stream_copy/protocol.py
+++ b/pg_stream_copy/protocol.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from struct import pack
 from typing import List, Tuple, cast
@@ -6,9 +6,9 @@ from typing import List, Tuple, cast
 # https://www.postgresql.org/docs/10/sql-copy.html - Binary Format section
 
 pg_null = pack('>I', 0xFFFFFFFF)
-pg_datetime_epoch = datetime(2000, 1, 1)  # https://www.postgresql.org/message-id/d34l6e%24284h%241%40news.hub.org
-pg_date_epoch = pg_datetime_epoch.date()
-pg_timestamp_epoch = pg_datetime_epoch.timestamp()
+pg_date_epoch = date(2000, 1, 1)
+pg_timestamp_epoch = datetime(2000, 1, 1).timestamp()
+pg_timestamp_tz_epoch = datetime(2000, 1, 1, tzinfo=timezone.utc).timestamp()
 
 
 ################################################################################
@@ -142,13 +142,19 @@ def build_date(day: date) -> bytes:
 
 
 def build_timestamp(value: datetime):
+    if value.tzinfo is not None:
+        raise Exception('datatime with timezone cannot be used for timestamp field')
+
     timestamp_ms = int((value.timestamp() - pg_timestamp_epoch) * 1_000_000)
     return _build_value(pack('>q', timestamp_ms))
 
 
 def build_timestamp_tz(value: datetime):
-    return build_timestamp(value)
+    if value.tzinfo is None:
+        raise Exception('datatime without timezone cannot be used for timestamptz field')
 
+    timestamp_ms = int((value.timestamp() - pg_timestamp_tz_epoch) * 1_000_000)
+    return _build_value(pack('>q', timestamp_ms))
 
 def build_json(value: str) -> bytes:
     return build_character_varying(value)

--- a/pg_stream_copy/schema.py
+++ b/pg_stream_copy/schema.py
@@ -21,7 +21,7 @@ class DataType(Enum):
     CHARACTER_VARYING = auto()  # str
     TEXT = auto()  # str
     DATE = auto()  # datetime.date
-    TIMESTAMP = auto()  # datetime.datetime
+    TIMESTAMP = auto()  # datetime.datetime without timezone
     TIMESTAMP_TZ = auto()  # datetime.datetime with timezone
     JSON = auto()  # str, eg. json.dumps({})
     JSONB = auto()  # bytes, eg. bytes(json.dumps({}), 'utf-8')


### PR DESCRIPTION
When timezone-aware datetime was used on non-utc machine, epoch differences calculated in `protocol.build_timestamp` / `protocol.build_timestamp_tz` were offseted by local machine timezone offset.

From now `protocol.build_timestamp` will also not accept timezone-aware datetimes, `protocol.build_timestamp_tz` won't accept non-timezone-aware datetimes